### PR TITLE
Prevent crash when executed during OOBE

### DIFF
--- a/WPNinjas.Dsregcmd/DsRegCmd.cs
+++ b/WPNinjas.Dsregcmd/DsRegCmd.cs
@@ -42,8 +42,11 @@ namespace WPNinjas.Dsregcmd
                 result.MdmTermsOfUseUrl = joinInfo.MdmTermsOfUseUrl;
                 result.TenantDisplayName = joinInfo.TenantDisplayName;
 
-                byte[] data = System.Convert.FromBase64String(joinInfo.UserSettingSyncUrl);
-                result.UserSettingSyncUrl = System.Text.ASCIIEncoding.ASCII.GetString(data);
+                if (joinInfo.UserSettingSyncUrl != null)
+                {
+                    byte[] data = System.Convert.FromBase64String(joinInfo.UserSettingSyncUrl);
+                    result.UserSettingSyncUrl = System.Text.ASCIIEncoding.ASCII.GetString(data);
+                }
 
                 // Userinfo
                 try


### PR DESCRIPTION
Only decode UserSettingSyncUrl when it is not null, which can occur when this code is executing during the OOBE process.